### PR TITLE
Allow optional SPI port to be passed so it also works on other hw SPI ports

### DIFF
--- a/examples/touch-CustomSPI.ino
+++ b/examples/touch-CustomSPI.ino
@@ -1,0 +1,73 @@
+
+/*
+ * touch-CustomSPI.ino
+ *
+ *  Created on: 20.02.2016
+ *  Updated 2024-01-20 by marcelrv
+ *
+ * required librarys:
+ *  - SPI (arduino core)
+ *  - XPT2046 (https://github.com/Links2004/XPT2046)
+ */
+
+#include <Arduino.h>
+#include <SPI.h>
+#include <XPT2046.h>
+
+#define XPT2046_IRQ 36
+#define XPT2046_MOSI 32
+#define XPT2046_MISO 39
+#define XPT2046_CLK 25
+#define XPT2046_CS 33
+
+// Note: the ESP32 has 2 SPI ports, to have ESP32-2432S028R work with the TFT and Touch on different SPI ports each needs to be defined and passed to the library
+SPIClass vspi = SPIClass(VSPI);
+
+XPT2046 touch = XPT2046(XPT2046_CS, XPT2046_IRQ, vspi);
+
+void touchEvent(bool press, uint16_t x, uint16_t y, uint16_t z)
+{
+    Serial.print("[Touch] press: ");
+    Serial.print(press);
+    Serial.print(" X: ");
+    Serial.print(x);
+    Serial.print(" Y: ");
+    Serial.print(y);
+    Serial.print(" Z: ");
+    Serial.println(z);
+}
+
+void setup()
+{
+
+    Serial.begin(115200);
+    Serial.println("[setup] Start...");
+
+    // Setup the custom SPI port pins, or just use the default pins with vspi.begin();
+    vspi.begin(XPT2046_CLK, XPT2046_MISO, XPT2046_MOSI, XPT2046_CS);
+
+    touch.begin(320, 240);                      // screen resolution
+    touch.setRotation(1);                       // match the cords to screen
+    touch.setCalibration(350, 550, 3550, 3600); // Calibrat screen
+
+    // call back for change
+    // parameter:
+    // 1 - minimum pixel move for new event
+    // 2 - minimum z for a event
+    // 3 - callback
+    touch.onChange(3, 200, touchEvent);
+
+    Serial.println("[setup] Done.");
+}
+
+long ts = 0;
+void loop()
+{
+    touch.loop();
+
+    if (ts + 5000 < millis()) // Show I'm still alive and kicking
+    {
+        printf(" ts: %d\n", millis());
+        ts = millis();
+    }
+}

--- a/src/XPT2046.cpp
+++ b/src/XPT2046.cpp
@@ -242,9 +242,9 @@ inline void XPT2046::spiCsLow(void) {
 }
 
 inline void XPT2046::spi_begin(void) {
-    SPI.beginTransaction(_spiSettings);
+    _pspi->beginTransaction(_spiSettings);
 }
 
 inline void XPT2046::spi_end(void) {
-    SPI.endTransaction();
+    _pspi->endTransaction();
 }

--- a/src/XPT2046.h
+++ b/src/XPT2046.h
@@ -29,59 +29,56 @@
 #include <SPI.h>
 
 class XPT2046 {
-    public:
-        typedef void (*XPT204Event)(bool press, uint16_t x, uint16_t y, uint16_t z);
+public:
+    typedef void (*XPT204Event)(bool press, uint16_t x, uint16_t y, uint16_t z);
 
-        XPT2046(int8_t CS, int8_t IRQ);
-        ~XPT2046();
-        void begin(uint16_t width, uint16_t height);
-        void loop();
+    XPT2046(int8_t CS, int8_t IRQ, SPIClass &wspi=SPI);
+    ~XPT2046();
+    void begin(uint16_t width, uint16_t height);
+    void loop();
 
-        void setRotation(uint8_t m);
-        void setCalibration(uint16_t minX, uint16_t minY, uint16_t maxX, uint16_t maxY);
+    void setRotation(uint8_t m);
+    void setCalibration(uint16_t minX, uint16_t minY, uint16_t maxX, uint16_t maxY);
 
-        void read(uint16_t * oX, uint16_t * oY, uint16_t * oZ);
-        void readRaw(uint16_t * oX, uint16_t * oY, uint16_t * oZ);
+    void read(uint16_t *oX, uint16_t *oY, uint16_t *oZ);
+    void readRaw(uint16_t *oX, uint16_t *oY, uint16_t *oZ);
 
-        void onChange(uint16_t min, uint16_t pressure, XPT204Event cb);
-    protected:
-        int8_t _pinCs;
-        int8_t _pinIrq;
+    void onChange(uint16_t min, uint16_t pressure, XPT204Event cb);
 
-        uint16_t _width;
-        uint16_t _height;
+protected:
+    int8_t _pinCs;
+    int8_t _pinIrq;
 
-        uint16_t _rotation;
+    uint16_t _width;
+    uint16_t _height;
 
-        uint16_t _minX;
-        uint16_t _minY;
+    uint16_t _rotation;
 
-        uint16_t _maxX;
-        uint16_t _maxY;
+    uint16_t _minX;
+    uint16_t _minY;
 
-        uint16_t _maxValue;
+    uint16_t _maxX;
+    uint16_t _maxY;
 
-        SPISettings _spiSettings;
+    uint16_t _maxValue;
 
-        int _lastX;
-        int _lastY;
+    SPIClass *_pspi = nullptr;
+    SPISettings _spiSettings;
 
-        uint16_t _minChange;
-        uint16_t _pressure;
-        XPT204Event _cb;
+    int _lastX;
+    int _lastY;
 
-        void enableIrq();
+    uint16_t _minChange;
+    uint16_t _pressure;
+    XPT204Event _cb;
 
-        inline void spiCsHigh(void) __attribute__((always_inline));
-        inline void spiCsLow(void) __attribute__((always_inline));
+    void enableIrq();
 
-        inline void spi_begin(void) __attribute__((always_inline));
-        inline void spi_end(void) __attribute__((always_inline));
+    inline void spiCsHigh(void) __attribute__((always_inline));
+    inline void spiCsLow(void) __attribute__((always_inline));
 
+    inline void spi_begin(void) __attribute__((always_inline));
+    inline void spi_end(void) __attribute__((always_inline));
 };
-
-
-
-
 
 #endif /* XPT2046_H_ */


### PR DESCRIPTION
The  ESP32-2432S028R aka Cheap Yellow Display has non-standard spi port settings.
This change allows the library to use alternative SPI ports

also closing #4